### PR TITLE
Add an initialVisibility prop to subtitles component

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ If necessary, you can render the subtitles outside of the player using the `EkoS
 
 | Prop           | Type           | Description  |
 | :-------------: |:--------------:| :------------|
-| style | `object` | Used to style the subtitles element. |  
+| style | `object` | Used to style the subtitles element. |
+| initialVisibility | `boolean` | Used to set if the subtitles are visible by default or not. |  
 
 **Note:** If you are using the `EkoSubtitles` component, you **must** also use `EkoPlayerProvider` so the subtitles component can access the player. See below for example usage.
 
@@ -169,6 +170,6 @@ Example:
 ```jsx
 <EkoPlayerProvider>
     <EkoVideo id="AWLLK1"/>
-    <EkoSubtitles style = {{color: 'white', background: 'black'}}/>
+    <EkoSubtitles style = {{color: 'white', background: 'black'}} initialVisibility={true}/>
 </EkoPlayerProvider>
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ekolabs/eko-react-sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A react component that embeds eko videos",
   "main": "dist/bundles/bundle.js",
   "homepage": "https://ekolabs.github.io/eko-react-sdk/",

--- a/src/PlayerPluginsService.js
+++ b/src/PlayerPluginsService.js
@@ -1,0 +1,64 @@
+/**
+ * Keeps track of the player plugin initialized state and exposes a promise-based API
+ * that allows others to wait until a plugin is initialized to perform some action.
+ * This should be exposed as part of the EkoPlayerContext
+ */
+class PlayerPluginsService {
+    constructor(player) {
+        this._player = player;
+        this._pluginInitedMap = {};
+        this.onPluginInited = this.onPluginInited.bind(this);
+        this.addEventListeners();
+    }
+
+    static init(player) {
+        if (!this._instance) {
+            this._instance = new PlayerPluginsService(player);
+        } else if (this._player && this._player !== player) { 
+            this._instance = new PlayerPluginsService(player);
+        }
+        return this._instance;
+    }
+
+    onPluginInited(name, version) {
+        // If the plugin doesn't exist in the map yet
+        if (!this._pluginInitedMap[name]) {
+            // Create a new, resolved promise for it, since this plugin has been initialized already
+            this._pluginInitedMap[name] = Promise.resolve(name);
+        }
+    }
+
+    pluginInited(name) {
+        // Check if a promsie already exists for this plugin (i.e. it's already been initialized)
+        // or create a new promise for this plugin
+        let promise = this._pluginInitedMap[name] || new Promise((resolve, reject) => {
+            // Listen to the plugin init event, and only resolve if the name matches the plugin name passed in
+            this._player.on('plugininit', function checkPluginInit(pluginName, version) {
+                if (pluginName === name) {
+                    this._player.off('plugininit', checkPluginInit);
+                    resolve(name);
+                }
+            }.bind(this));
+        });
+        // Update the map
+        this._pluginInitedMap[name] = promise;
+        return this._pluginInitedMap[name];
+    }
+
+    addEventListeners() {
+        this._player.on('plugininit', this.onPluginInited);
+    }
+
+    removeEventListeners() {
+        this._player.off('plugininit', this.onPluginInited);
+    }
+
+    dispose() {
+        this.removeEventListeners();
+        this._instance = undefined;
+    }
+
+
+}
+
+export default PlayerPluginsService;

--- a/src/PlayerPluginsService.js
+++ b/src/PlayerPluginsService.js
@@ -14,8 +14,6 @@ class PlayerPluginsService {
     static init(player) {
         if (!this._instance) {
             this._instance = new PlayerPluginsService(player);
-        } else if (this._player && this._player !== player) { 
-            this._instance = new PlayerPluginsService(player);
         }
         return this._instance;
     }
@@ -55,7 +53,6 @@ class PlayerPluginsService {
 
     dispose() {
         this.removeEventListeners();
-        this._instance = undefined;
     }
 
 

--- a/src/components/EkoPlayerContext/EkoPlayerContext.jsx
+++ b/src/components/EkoPlayerContext/EkoPlayerContext.jsx
@@ -11,7 +11,7 @@ import React, {createContext, useState} from 'react';
 
 const EkoPlayerContext = createContext();
 function EkoPlayerProvider(props) {
-    const [playerState, setPlayerState] = useState({});
+    const [playerState, setPlayerState] = useState({player: undefined, pluginInited: undefined});
     return (
         <EkoPlayerContext.Provider value={{playerState, setPlayerState}}>
             {props.children}

--- a/src/components/EkoPlayerContext/EkoPlayerContext.jsx
+++ b/src/components/EkoPlayerContext/EkoPlayerContext.jsx
@@ -11,7 +11,7 @@ import React, {createContext, useState} from 'react';
 
 const EkoPlayerContext = createContext();
 function EkoPlayerProvider(props) {
-    const [playerState, setPlayerState] = useState({player: undefined, pluginInited: undefined});
+    const [playerState, setPlayerState] = useState({player: undefined, pluginInitedService: undefined});
     return (
         <EkoPlayerContext.Provider value={{playerState, setPlayerState}}>
             {props.children}

--- a/src/components/EkoSubtitles/EkoSubtitles.jsx
+++ b/src/components/EkoSubtitles/EkoSubtitles.jsx
@@ -42,7 +42,13 @@ export function EkoSubtitles({style, initialVisibility}) {
 
         const onVisibilityChange = (isVisible) =>  setVisible(isVisible);
         const onSubStart = (subObj) =>  setText(subObj.text);
-        const onSubEnd = (subObj) =>  setText('');
+        const onSubEnd = (subObj) =>  {
+            setText('');
+            //TO DO: remove this, its just to test the plugin inited api
+            pluginInited('audio').then((res) => {
+                console.log('AUDIOS BEEN LOADED');
+            })
+        }
         const onLangChange = (effectiveLanguage) =>  setEffectiveLang(effectiveLanguage);
         
         player.on('subtitles.visibilitychange', onVisibilityChange);
@@ -56,7 +62,7 @@ export function EkoSubtitles({style, initialVisibility}) {
             player.off('subtitles.subend', onSubEnd);
             player.off('subtitles.effectivelanguagechange', onLangChange);
         };
-    }, [player]);
+    }, [player, visible, pluginInited]);
 
     // Add right-to-left "direction" css for required languages.
     let rtl = RTL_LANGUAGES.includes(effectiveLang) ? 'rtl' : '';

--- a/src/components/EkoSubtitles/EkoSubtitles.jsx
+++ b/src/components/EkoSubtitles/EkoSubtitles.jsx
@@ -27,28 +27,21 @@ export function EkoSubtitles({style, initialVisibility}) {
         throw new Error('This component needs to be wrapped in a player context, but one was not found');
     }
     let player = context && context.playerState && context.playerState.player;
-    let pluginInited = context && context.playerState && context.playerState.pluginInited;
+    let pluginInitedService = context && context.playerState && context.playerState.pluginInitedService;
     
     useEffect(() => {
-        if (!player) {
+        if (!pluginInitedService || !player) {
             return;
         }
-        if (pluginInited) {
-            pluginInited('subtitles').then((res) => {
-                player.invoke('subtitles.mode', 'proxy');
-                player.invoke('subtitles.visible', visible);
-            });
-        }
+        
+        pluginInitedService.pluginInited('subtitles').then((res) => {
+            player.invoke('subtitles.mode', 'proxy');
+            player.invoke('subtitles.visible', initialVisibility);
+        });
 
         const onVisibilityChange = (isVisible) =>  setVisible(isVisible);
         const onSubStart = (subObj) =>  setText(subObj.text);
-        const onSubEnd = (subObj) =>  {
-            setText('');
-            //TO DO: remove this, its just to test the plugin inited api
-            pluginInited('audio').then((res) => {
-                console.log('AUDIOS BEEN LOADED');
-            })
-        }
+        const onSubEnd = (subObj) =>  setText('');
         const onLangChange = (effectiveLanguage) =>  setEffectiveLang(effectiveLanguage);
         
         player.on('subtitles.visibilitychange', onVisibilityChange);
@@ -62,7 +55,7 @@ export function EkoSubtitles({style, initialVisibility}) {
             player.off('subtitles.subend', onSubEnd);
             player.off('subtitles.effectivelanguagechange', onLangChange);
         };
-    }, [player, visible, pluginInited]);
+    }, [player, pluginInitedService]);
 
     // Add right-to-left "direction" css for required languages.
     let rtl = RTL_LANGUAGES.includes(effectiveLang) ? 'rtl' : '';

--- a/src/components/EkoSubtitles/EkoSubtitles.jsx
+++ b/src/components/EkoSubtitles/EkoSubtitles.jsx
@@ -14,11 +14,12 @@ const AD_LANGUAGES = ['en-US-AD'];
  * @type {React.Component}
  * @param {object} props
  * @param {object} props.style - Used to style the subtitles component
+ * @param {boolean} props.initialVisibility - Used to determine if the subtitles should be visible by default or not
  *
  */
-export function EkoSubtitles({style}) {
+export function EkoSubtitles({style, initialVisibility}) {
 
-    const [visible, setVisible] = useState(false);
+    const [visible, setVisible] = useState(initialVisibility || false);
     const [text, setText] = useState('');
     const [effectiveLang, setEffectiveLang] = useState('');
     
@@ -68,5 +69,6 @@ export function EkoSubtitles({style}) {
 }
 
 EkoSubtitles.propTypes = {
-    style: PropTypes.object
+    style: PropTypes.object,
+    initialVisibility: PropTypes.bool
 };

--- a/src/components/EkoSubtitles/EkoSubtitles.jsx
+++ b/src/components/EkoSubtitles/EkoSubtitles.jsx
@@ -32,6 +32,9 @@ export function EkoSubtitles({style, initialVisibility}) {
         if (!player) {
             return;
         }
+        if (typeof initialVisibility !== 'undefined') {
+            player.invoke('subtitles.visible', initialVisibility);
+        }
         const onSubtitlesInit = () => player.invoke('subtitles.mode', 'proxy');
         const onVisibilityChange = (isVisible) =>  setVisible(isVisible);
         const onSubStart = (subObj) =>  setText(subObj.text);

--- a/src/components/EkoVideo/EkoVideo.jsx
+++ b/src/components/EkoVideo/EkoVideo.jsx
@@ -69,7 +69,7 @@ export function EkoVideo({
     });
 
     let context = useContext(EkoPlayerContext);
-    let pluginInitedMap = {};
+    const [pluginInitedMap, setPluginInitedMap] = useState({});
     const ekoProjectContainer = useRef(null);
     const onCoverStateChanged = (state, params) => {
         setPlayerLoadingState({state, params});
@@ -118,7 +118,10 @@ export function EkoVideo({
 
         const onPluginInited = (pluginName, version) => {
             if (!pluginInitedMap[pluginName]) {
-                pluginInitedMap[pluginName] = Promise.resolve(pluginName);
+                setPluginInitedMap((prevState) => ({
+                    ...prevState,
+                    [pluginName]: Promise.resolve(pluginName)
+                }));
             }
         }
         
@@ -132,8 +135,13 @@ export function EkoVideo({
                     }
                 });
             });
-            pluginInitedMap[name] = promise;
-            return pluginInitedMap[name];
+
+            setPluginInitedMap((prevState) => ({
+                ...prevState,
+                [name]: promise
+            }));
+            
+            return promise;
         }
 
         if (context && context.setPlayerState) {
@@ -175,7 +183,7 @@ export function EkoVideo({
     let containerClassNames = ["eko_component_container"];
     containerClassNames.push(expandToFillContainer?"expand":"intrinsicSize")
 
-
+    console.log(pluginInitedMap);
     // Render eko video
     return (
         <div className={containerClassNames.join(" ")}>

--- a/src/components/EkoVideo/EkoVideo.jsx
+++ b/src/components/EkoVideo/EkoVideo.jsx
@@ -161,7 +161,7 @@ export function EkoVideo({
                     boundHandlers[eventName].forEach( handler => playerRef.current.off(eventName, handler));
                 })
             }
-            playerRef.current.off('plugininited', onPluginInited);
+            playerRef.current.off('plugininit', onPluginInited);
         };
 
     }, [playerRef.current, id]);

--- a/src/stories/EkoSubtitles.stories.js
+++ b/src/stories/EkoSubtitles.stories.js
@@ -6,7 +6,8 @@ export default {
     title: 'Example/EkoSubtitles',
     component: EkoSubtitles,
     argTypes: {
-        style: {}
+        style: {},
+        initialVisibility: {}
     },
     parameters: {
         docs: {
@@ -36,7 +37,8 @@ const defaultArgs = {
     seekTime: 2,
     params: {
         clearcheckpoints: true,
-        autoplay: true
+        autoplay: true,
+        subtitlesmode: 'proxy'
     },
 };
 
@@ -53,7 +55,8 @@ const defaultParams = {
 export const SimpleSubtitles = ExternalSubtitlesTemplate.bind({});
 SimpleSubtitles.args = {
     ...defaultArgs,
-    style: {background: 'black', color: 'white', padding: '10px 30px'}
+    style: {background: 'black', color: 'white', padding: '10px 30px'},
+    initialVisibility: true
 }
 
 SimpleSubtitles.parameters ={
@@ -64,7 +67,8 @@ SimpleSubtitles.parameters ={
 export const StyledSubtitles = ExternalSubtitlesTemplate.bind({});
 StyledSubtitles.args = {
     ...defaultArgs,
-    style: {background: 'black', color: 'red', padding: '10px 30px', font: '18px Arial'}
+    style: {background: 'black', color: 'red', padding: '10px 30px', font: '18px Arial'},
+    initialVisibility: true
 }
 
 StyledSubtitles.parameters ={

--- a/src/stories/ExternalSubtitlesTemplate/ExternalSubtitlesTemplate.js
+++ b/src/stories/ExternalSubtitlesTemplate/ExternalSubtitlesTemplate.js
@@ -6,14 +6,15 @@ import {EkoPlayerProvider} from '../../components/EkoPlayerContext/EkoPlayerCont
 export default function ExternalSubtitlesTemplate(args, context){
     args.onPlayerInit = (player) => { 
         if (player) {
-            player.once('plugininitsubtitles', () => {
-                player.invoke('subtitles.visible', true);
-                player.invoke('subtitles.language', 'en');
+            player.on('plugininit', (pluginName) => {
+                if (pluginName === 'subtitles') {
+                    player.invoke('subtitles.visible', true);
+                    player.invoke('subtitles.language', 'en');
+                }
             });
         } 
     };
     let ekoVideo = EkoVideoTemplate(args, context);
-    let style = args.style || {};
     return (
         <EkoPlayerProvider>
             <div style={{height: 100 + '%', width: 100 + '%'}}>
@@ -21,7 +22,7 @@ export default function ExternalSubtitlesTemplate(args, context){
                     {ekoVideo}
                 </div>
                 <h5 style={{padding: '10px 30px', margin: 0, color: 'white', background: 'black'}}>External Subtitles Below:</h5>
-                <EkoSubtitles style={style}/>
+                <EkoSubtitles {...args}/>
             </div>
         </EkoPlayerProvider>
     )


### PR DESCRIPTION
This is because there are times when the subtitles plugin has already been initialized by the time the component is initialized, which results in the component failing to get the visibilitychanged event. So, if subtitles are on by default in the player and this component is initialized after the subtitles plugin, the subtitles will never appear externally. To fix, allow the component's initial visibility to be set (don't rely solely on listening to the event).